### PR TITLE
新しい予定を追加画面の登録処理を実装

### DIFF
--- a/TabishioriApp/Model/PlanDataModel.swift
+++ b/TabishioriApp/Model/PlanDataModel.swift
@@ -1,0 +1,21 @@
+//
+//  PlanDataModel.swift
+//  TabishioriApp
+//
+//  Created by 田村伊吹 on 2025/08/21.
+//
+
+import Foundation
+import RealmSwift
+
+/// 予定のデータモデル
+final class PlanDataModel: Object {
+    @Persisted var planDate: Date
+    @Persisted var startTime: Date?
+    @Persisted var endTime: Date?
+    @Persisted var planContent: String = ""
+    @Persisted var planReservation: Bool = false
+    @Persisted var planCost: Int = 0
+    @Persisted var planURL: String = ""
+    @Persisted var planImage: String = ""
+}


### PR DESCRIPTION
## やったこと
* しおりの予定の登録処理を実装
* しおりの予定の日付と内容は記載必須になるように実装

## 動作確認
- [ ] 追加ボタンタップ時に「登録できました」とメッセージが表示できることを確認した
- [ ] しおりの日付と内容が無記載の場合、エラーが表示できることを確認した