### PR TITLE
予定の情報を追加画面に取得データを渡す処理を実装

### DIFF
--- a/TabishioriApp/View/EditShioriPlanDetailViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.swift
@@ -10,6 +10,55 @@ import UIKit
 /// しおり予定情報編集画面
 final class EditShioriPlanDetailViewController: UIViewController {
     
+    // MARK: - Stored Properties
+    
+    /// 日付
+    private var selectedDate: Date?
+    /// 開始時間
+    private var selectedStartTime: Date?
+    /// 終了時間
+    private var selectedEndTime: Date?
+    /// 予定の内容
+    private var selectedPlan: String = ""
+    /// 予約可否
+    private var selectedReservation: Bool = false
+    /// 費用
+    private var selectedCost: Int?
+    /// URL
+    private var selectedURL: String = ""
+    /// 画像
+    private var selectedImage: String?
+    /// 日付ピッカー
+    private let datePickerDate = UIDatePicker()
+    /// 開始時間ピッカー
+    private let datePickerStartTime = UIDatePicker()
+    /// 終了時間ピッカー
+    private let datePickerEndTime = UIDatePicker()
+    /// しおり予定データ
+    private var planDataModel: PlanDataModel
+    
+    // MARK: - Computed Properties
+    
+    /// 日付取得のフォーマット
+    private let dateFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "ja_JP")
+        df.calendar = Calendar(identifier: .gregorian)
+        df.dateFormat = "yyyy年M月d日"
+        return df
+    }()
+    
+    /// 時間取得のフォーマット
+    private let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "ja_JP")
+        //formatter.dateStyle = .medium
+        //formatter.timeStyle = .none
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+    
     // MARK: - IBOutlets
     
     /// 予定情報の修正ラベル
@@ -40,10 +89,23 @@ final class EditShioriPlanDetailViewController: UIViewController {
     @IBOutlet private weak var endTimeTextField: UITextField!
     /// 予定内容記入欄
     @IBOutlet private weak var planTextView: UITextView!
+    /// 予約可否ボタン
+    @IBOutlet private weak var reservationCheckButton: UIButton!
     /// 費用記入欄
     @IBOutlet private weak var costTextField: UITextField!
     /// URL記入欄
     @IBOutlet private weak var urlTextField: UITextField!
+    /// 画像プレビュー
+    @IBOutlet private weak var planImageView: UIImageView!
+    
+    init(planDataModel: PlanDataModel) {
+        self.planDataModel = planDataModel
+        super.init(nibName: "EditShioriPlanDetailViewController", bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     // MARK: - View Life-Cycle Methods
     
@@ -53,12 +115,17 @@ final class EditShioriPlanDetailViewController: UIViewController {
         configureTextField()
         configureTextView()
         configureBarButtonItems()
+        setPlanFromRealm()
+        setReservationCheckBox()
     }
     
     // MARK: - IBActions
     
     /// 要予約のチェックボックスをタップ
     @IBAction private func checkBoxButtonTapped(_ sender: UIButton) {
+        sender.isSelected.toggle()
+        selectedReservation = sender.isSelected
+        
     }
     
     /// 画像をを挿入するボタンをタップ
@@ -159,6 +226,61 @@ final class EditShioriPlanDetailViewController: UIViewController {
     
     @objc func backButtonTapped() {
         navigationController?.popViewController(animated: true)
+    }
+    
+    /// Realmから予定の情報をセット
+    private func setPlanFromRealm() {
+        let model = planDataModel
+        
+        selectedDate = model.planDate
+        selectedStartTime = model.startTime
+        selectedEndTime = model.endTime
+        selectedPlan = model.planContent
+        selectedReservation = model.planReservation
+        selectedCost = model.planCost
+        selectedURL = model.planURL
+        selectedImage = model.planImage
+        
+        dateTextField.text = dateFormatter.string(from: selectedDate!)
+        startTimeTextField.text = timeFormatter.string(from: selectedStartTime!)
+        endTimeTextField.text = timeFormatter.string(from: selectedEndTime!)
+        planTextView.text = selectedPlan
+        reservationCheckButton.isSelected = selectedReservation
+        if let cost = selectedCost, cost != 0 {
+            costTextField.text = String(cost)
+        } else {
+            costTextField.text = ""
+        }
+        urlTextField.text = selectedURL
+        if let imageName =  selectedImage {
+            planImageView.image = imageFromIdentifer(imageName)
+        } else {
+            planImageView.image = nil
+        }
+    }
+    
+    /// 予約チェックボックスの画像表示
+    private func setReservationCheckBox() {
+        reservationCheckButton.setImage(UIImage(named: "ic_check_box_out"), for: .normal)   // false用
+        reservationCheckButton.setImage(UIImage(named: "ic_check_box_in"),  for: .selected) // true用
+    }
+    
+    /// 画像の型の変更
+    private func imageFromIdentifer(_ identifier: String) -> UIImage? {
+        let trimmedIdentifier = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedIdentifier.isEmpty else { return nil}
+        
+        if trimmedIdentifier.hasPrefix("data:image/"),
+           let commaIdex = trimmedIdentifier.firstIndex(of: ",") {
+            let base64String = String(trimmedIdentifier[trimmedIdentifier.index(after: commaIdex)...])
+            if let data = Data(base64Encoded: base64String, options: .ignoreUnknownCharacters) {
+                return UIImage(data: data)
+            }
+        }
+        if let data = Data(base64Encoded: trimmedIdentifier, options: .ignoreUnknownCharacters) {
+            return UIImage(data: data)
+        }
+        return UIImage(named: trimmedIdentifier)
     }
 }
 

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.xib
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.xib
@@ -18,8 +18,10 @@
                 <outlet property="endTimeLabel" destination="iqu-uM-e5O" id="1tS-Oe-Qkp"/>
                 <outlet property="endTimeTextField" destination="svl-YY-goj" id="Xll-bk-AJY"/>
                 <outlet property="insertImageButton" destination="9Oe-1q-fId" id="KPd-wx-RK4"/>
+                <outlet property="planImageView" destination="dhr-UY-4kP" id="YsF-31-Mng"/>
                 <outlet property="planLabel" destination="gjQ-Pg-DDC" id="Ecp-lv-DOa"/>
                 <outlet property="planTextView" destination="GrO-jw-XER" id="wgQ-Rc-mM7"/>
+                <outlet property="reservationCheckButton" destination="5UA-I9-kEK" id="leS-ZN-bN5"/>
                 <outlet property="reservationLabel" destination="wma-O4-buD" id="BPQ-hh-94Y"/>
                 <outlet property="startTimeLabel" destination="7la-AK-HrU" id="SI0-Bo-ucQ"/>
                 <outlet property="startTimeTextField" destination="Brk-xl-bJr" id="dua-oH-Iuf"/>

--- a/TabishioriApp/View/EditShioriPlanViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanViewController.swift
@@ -23,6 +23,8 @@ final class EditShioriPlanViewController: UIViewController {
     
     /// しおりのデータ
     private var dataModel: ShioriDataModel!
+    /// 予定のデータ
+    private var planDataModel: PlanDataModel!
     
     // MARK: - Stored Properties
     
@@ -185,7 +187,9 @@ final class EditShioriPlanViewController: UIViewController {
     /// 予定データを取得する
     private func fetchDailyPlans() {
         let results = realmManager.getObjects(PlanDataModel.self)
-        self.dailyPlans = results.filter { Calendar.current.isDate($0.planDate, inSameDayAs: self.pageDate)}
+        self.dailyPlans = results
+            .filter { Calendar.current.isDate($0.planDate, inSameDayAs: self.pageDate)}
+            .sorted{ $0.startTime < $1.startTime }
         planTableView.reloadData()
     }
     
@@ -247,11 +251,15 @@ extension EditShioriPlanViewController: UITableViewDataSource {
 /// セル横の編集ボタンをタップ
 extension EditShioriPlanViewController: ShioriPlanTableViewCellDelegate {
     func didTapRightButton(in cell: ShioriPlanTableViewCell) {
-        navigateToEditShioriPlanDetail()
+        guard let indexPath = planTableView.indexPath(for: cell) else {
+            return
+        }
+        let plan = dailyPlans[indexPath.row]
+        navigateToEditShioriPlanDetail(plan: plan)
         }
     
-    private func navigateToEditShioriPlanDetail() {
-        let nextVC = EditShioriPlanDetailViewController()
+    private func navigateToEditShioriPlanDetail(plan: PlanDataModel) {
+        let nextVC = EditShioriPlanDetailViewController(planDataModel: plan)
         navigationController?.pushViewController(nextVC, animated: true)
     }
 }

--- a/TabishioriApp/View/ShioriContentViewController.swift
+++ b/TabishioriApp/View/ShioriContentViewController.swift
@@ -173,7 +173,7 @@ final class ShioriContentViewController: UIViewController {
     private func fetchPlansForThisDay() -> [PlanDataModel] {
         let results = RealmManager.shared.getObjects(PlanDataModel.self)
             .filter { Calendar.current.isDate($0.planDate, inSameDayAs: self.pageDate) }
-        return Array(results)
+        return results.sorted { $0.startTime < $1.startTime }
     }
 }
 


### PR DESCRIPTION
## やったこと
* realmに保存したしおりの予定を予定情報の修正画面に渡して表示する処理を実装
* 予定を予定開始時間を昇順で並べて表示する処理を実装

## 動作確認
- [X] 予定情報の修正画面で、登録した予定情報がデフォルトで入っていることを確認した
- [X] 作成した予定が開始時間を標準で表示できることを確認した

## 動画
https://github.com/user-attachments/assets/b2018512-56a2-4fe8-8cea-a008e636884a


