### PR TITLE
予定の情報を追加画面にRealmの更新処理を実装

### DIFF
--- a/TabishioriApp/View/CreateShioriPlanViewController.swift
+++ b/TabishioriApp/View/CreateShioriPlanViewController.swift
@@ -145,15 +145,6 @@ final class CreateShioriPlanViewController: UIViewController {
         // URLを登録
         selectedURL = urlTextField.text ?? ""
         validatePlanForm()
-        
-        // 確認用
-        print("selectedDate: \(String(describing: selectedDate))")
-        print("selectedStartTime: \(String(describing: selectedStartTime))")
-        print("selectedEndTime: \(String(describing: selectedEndTime))")
-        print("selectedPlan: \(selectedPlan)")
-        print("selectedReservation: \(selectedReservation)")
-        print("selectedCost: \(selectedCost?.description ?? "nil")")
-        print("selectedURL: \(selectedURL)")
     }
     
     // MARK: - Other Methods

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.swift
@@ -63,8 +63,6 @@ final class EditShioriPlanDetailViewController: UIViewController {
     private let timeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .init(identifier: "ja_JP")
-        //formatter.dateStyle = .medium
-        //formatter.timeStyle = .none
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.dateFormat = "HH:mm"
         return formatter

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import RealmSwift
 
 // MARK: - Protocols
 
@@ -453,13 +452,14 @@ final class EditShioriPlanDetailViewController: UIViewController {
     private func updatePlan(planDate: Date, startTime: Date) {
         guard let model = planDataModel else { return }
         
-            realmManager.update(onSuccess: {
-                // 成功時の処理
-                DispatchQueue.main.async { [weak self] in
-                    guard let self = self else { return }
-                    print("Object added successfully")
-                    let alert = UIAlertController(title: "更新しました", message: nil, preferredStyle: .alert)
-                    self.present(alert, animated: true) {
+        realmManager.update(
+            onSuccess: {
+            // 成功時の処理
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                print("Object added successfully")
+                let alert = UIAlertController(title: "更新しました", message: nil, preferredStyle: .alert)
+                self.present(alert, animated: true) {
                     
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
                         guard let self = self else { return }
@@ -473,27 +473,27 @@ final class EditShioriPlanDetailViewController: UIViewController {
                             }
                         }
                         alert.dismiss(animated: true, completion: closeModal)
-                        }
                     }
                 }
-            }, onFailure: { [weak self] error in
-                    // 失敗時の処理
-                    print("Failed to add object to Realm: \(error)")
-                    DispatchQueue.main.async {
-                        self?.showAlert(title: "更新に失敗しました")
-                    }
-                })
-                {
-                model.planDate = planDate
-                model.startTime = startTime
-                model.endTime = selectedEndTime
-                model.planContent = selectedPlan
-                model.planReservation = selectedReservation
-                model.planCost = selectedCost ?? 0
-                model.planURL = selectedURL
-                model.planImage = selectedImage
             }
+        }, onFailure: { [weak self] error in
+            // 失敗時の処理
+            print("Failed to add object to Realm: \(error)")
+            DispatchQueue.main.async {
+                self?.showAlert(title: "更新に失敗しました")
+            }
+        })
+        {
+            model.planDate = planDate
+            model.startTime = startTime
+            model.endTime = selectedEndTime
+            model.planContent = selectedPlan
+            model.planReservation = selectedReservation
+            model.planCost = selectedCost ?? 0
+            model.planURL = selectedURL
+            model.planImage = selectedImage
         }
+    }
     
     /// アラートを表示
     private func showAlert(title: String) {

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.xib
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.xib
@@ -163,7 +163,7 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                     <connections>
-                        <action selector="editButtonTapped:" destination="-1" eventType="touchUpInside" id="bwZ-Fv-78R"/>
+                        <action selector="correctButtonTapped:" destination="-1" eventType="touchUpInside" id="bwZ-Fv-78R"/>
                     </connections>
                 </button>
                 <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gY6-ck-hzU">

--- a/TabishioriApp/View/EditShioriPlanViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanViewController.swift
@@ -11,7 +11,8 @@ import RealmSwift
 // MARK: - Protocols
 
 protocol EditShioriPlanViewControllerDelegate: AnyObject {
-    func didShioriupdate(_ updated: ShioriDataModel)
+    func didShioriUpdate(_ updated: ShioriDataModel)
+    func didPlanUpdate(_ plan: PlanDataModel)
 }
 
 // MARK: - Main Type
@@ -205,7 +206,7 @@ final class EditShioriPlanViewController: UIViewController {
         let hasURL = !trimmedURL.isEmpty
         let rawImage = plan.planImage?.trimmingCharacters(in: .whitespacesAndNewlines)
         let imageName: String? = (rawImage?.isEmpty == false) ? rawImage : nil
-
+        
         
         return .init(startTime: plan.startTime,
                      endTime: plan.endTime,
@@ -262,16 +263,28 @@ extension EditShioriPlanViewController: ShioriPlanTableViewCellDelegate {
         }
         let plan = dailyPlans[indexPath.row]
         navigateToEditShioriPlanDetail(plan: plan)
-        }
+    }
     
     private func navigateToEditShioriPlanDetail(plan: PlanDataModel) {
         let nextVC = EditShioriPlanDetailViewController(planDataModel: plan)
+        nextVC.delegate = self
         navigationController?.pushViewController(nextVC, animated: true)
     }
 }
 
 extension EditShioriPlanViewController: EditShioriViewControllerDelegate {
     func didSaveNewShiori(_ updated: ShioriDataModel) {
-        delegateToParent?.didShioriupdate(updated)
+        delegateToParent?.didShioriUpdate(updated)
+    }
+}
+
+
+extension EditShioriPlanViewController: EditShioriPlanDetailViewControllerDelegate {
+    func didSavePlan(_ plan: PlanDataModel) {
+        fetchDailyPlans()
+        planTableView.reloadData()
+        
+        delegateToParent?.didPlanUpdate(plan)
+        
     }
 }

--- a/TabishioriApp/View/EditShioriViewController.swift
+++ b/TabishioriApp/View/EditShioriViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import RealmSwift
 
 // MARK: - Protocols
 

--- a/TabishioriApp/View/EditShioriViewController.swift
+++ b/TabishioriApp/View/EditShioriViewController.swift
@@ -370,7 +370,8 @@ final class EditShioriViewController: UIViewController {
     private func update(startDate: Date, endDate: Date) {
         guard let model = dataModel else { return }
         
-        realmManager.update(onSuccess: {
+        realmManager.update(
+            onSuccess: {
             // 成功時の処理
             print("Object added successfully")
             let alert = UIAlertController(title: "更新しました", message: nil, preferredStyle: .alert)

--- a/TabishioriApp/View/ShioriViewController.swift
+++ b/TabishioriApp/View/ShioriViewController.swift
@@ -223,7 +223,7 @@ extension ShioriViewController: CreateShioriPlanViewControllerDelegate {
 
 extension ShioriViewController: EditShioriPlanViewControllerDelegate {
     /// しおりの情報を更新
-    func didShioriupdate(_ updated: ShioriDataModel) {
+    func didShioriUpdate(_ updated: ShioriDataModel) {
         let currentDisplayedDate = (pageViewController.viewControllers?.first as? ShioriContentViewController)?.pageDate
         
         selectedShiori = updated
@@ -239,5 +239,18 @@ extension ShioriViewController: EditShioriPlanViewControllerDelegate {
         
         pageViewController.setViewControllers([pages[targetIndex]], direction: .forward, animated: false)
         updateAllPagesWithPlans()
+    }
+    
+    /// 予定の情報を更新
+    func didPlanUpdate(_ updated: PlanDataModel) {
+        let targetDate = updated.planDate
+        let cal = Calendar.current
+        for page in pages {
+            if let content = page as? ShioriContentViewController,
+               cal.isDate(content.pageDate, inSameDayAs: targetDate) {
+                content.fetchAndDistributePlans()
+                break
+            }
+        }
     }
 }


### PR DESCRIPTION
## やったこと
* しおりの予定を修正して登録し直す処理を実装
* 再登録後、しおり修正画面と、しおり画面の両方の予定表示を更新する処理を実装

## 動作確認
* しおりの予定内容を入力し直せることを確認した
* しおりの予定を修正後、しおり修正画面としおり画面に内容が反映されることを確認した

## 動画
https://github.com/user-attachments/assets/2cf3ab6c-3502-47c8-9f3b-3502cda392b2

