### PR TITLE
持ち物リスト画面にRealmの取得と登録処理を実装

### DIFF
--- a/TabishioriApp/Model/PackingItemDataModel.swift
+++ b/TabishioriApp/Model/PackingItemDataModel.swift
@@ -1,0 +1,15 @@
+//
+//  PackingItemDataModel.swift
+//  TabishioriApp
+//
+//  Created by 田村伊吹 on 2025/09/09.
+//
+
+import Foundation
+import RealmSwift
+
+/// 持ち物アイテムのデータモデル
+final class PackingItemDataModel: Object {
+    @Persisted var name: String = ""
+    @Persisted var isChecked: Bool = false
+}

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.swift
@@ -185,7 +185,8 @@ final class EditShioriPlanDetailViewController: UIViewController {
             .font: addButtonFont,
             .foregroundColor: UIColor.white
         ]
-        let addButtonAttributedTitle = NSAttributedString(string: addButtonTitle, attributes: addButtonAttributes)
+        let addButtonAttributedTitle = NSAttributedString(string: addButtonTitle,
+                                                          attributes: addButtonAttributes)
         editButton.setAttributedTitle(addButtonAttributedTitle, for: .normal)
         
         // 画像挿入ボタンのフォントを設定
@@ -196,7 +197,8 @@ final class EditShioriPlanDetailViewController: UIViewController {
             .foregroundColor: UIColor.systemBlue,
             .underlineStyle: NSUnderlineStyle.single.rawValue
         ]
-        let insertAttributeTitle = NSAttributedString(string: insertImageTitle, attributes: insertImageAttributes)
+        let insertAttributeTitle = NSAttributedString(string: insertImageTitle,
+                                                      attributes: insertImageAttributes)
         insertImageButton.setAttributedTitle(insertAttributeTitle, for: .normal)
     }
     
@@ -454,35 +456,35 @@ final class EditShioriPlanDetailViewController: UIViewController {
         
         realmManager.update(
             onSuccess: {
-            // 成功時の処理
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                print("Object added successfully")
-                let alert = UIAlertController(title: "更新しました", message: nil, preferredStyle: .alert)
-                self.present(alert, animated: true) {
-                    
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                        guard let self = self else { return }
-                        self.delegate?.didSavePlan(model)
+                // 成功時の処理
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    print("Object added successfully")
+                    let alert = UIAlertController(title: "更新しました", message: nil, preferredStyle: .alert)
+                    self.present(alert, animated: true) {
                         
-                        let closeModal: () -> Void = {
-                            if self.navigationController != nil {
-                                self.navigationController?.popViewController(animated: true)
-                            } else {
-                                self.dismiss(animated: true)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                            guard let self = self else { return }
+                            self.delegate?.didSavePlan(model)
+                            
+                            let closeModal: () -> Void = {
+                                if self.navigationController != nil {
+                                    self.navigationController?.popViewController(animated: true)
+                                } else {
+                                    self.dismiss(animated: true)
+                                }
                             }
+                            alert.dismiss(animated: true, completion: closeModal)
                         }
-                        alert.dismiss(animated: true, completion: closeModal)
                     }
                 }
-            }
-        }, onFailure: { [weak self] error in
-            // 失敗時の処理
-            print("Failed to add object to Realm: \(error)")
-            DispatchQueue.main.async {
-                self?.showAlert(title: "更新に失敗しました")
-            }
-        })
+            }, onFailure: { [weak self] error in
+                // 失敗時の処理
+                print("Failed to add object to Realm: \(error)")
+                DispatchQueue.main.async {
+                    self?.showAlert(title: "更新に失敗しました")
+                }
+            })
         {
             model.planDate = planDate
             model.startTime = startTime
@@ -524,15 +526,18 @@ extension EditShioriPlanDetailViewController: UITextFieldDelegate {
     /// ピッカーを開いた時に今の設定時刻で選択スタートする
     func textFieldDidBeginEditing(_ textField: UITextField) {
         if textField == dateTextField {
-            if let currentSelectedDate = selectedDate ?? parseDate(dateTextField.text, with: dateFormatter) {
+            if let currentSelectedDate = selectedDate ?? parseDate(dateTextField.text,
+                                                                   with: dateFormatter) {
                 datePickerDate.setDate(currentSelectedDate, animated: false)
             }
         } else if textField == startTimeTextField {
-            if let currentSelectedStartTime = selectedStartTime ?? parseDate(startTimeTextField.text, with: timeFormatter) {
+            if let currentSelectedStartTime = selectedStartTime ?? parseDate(startTimeTextField.text,
+                                                                             with: timeFormatter) {
                 datePickerStartTime.setDate(currentSelectedStartTime, animated: false)
             }
         } else if textField == endTimeTextField {
-            if let currentSelectedEndTime = selectedEndTime ?? parseDate(endTimeTextField.text, with: timeFormatter) {
+            if let currentSelectedEndTime = selectedEndTime ?? parseDate(endTimeTextField.text,
+                                                                         with: timeFormatter) {
                 datePickerEndTime.setDate(currentSelectedEndTime, animated: false)
             }
         }
@@ -555,16 +560,18 @@ extension EditShioriPlanDetailViewController: UITextViewDelegate {
 
 // MARK: - UIImagePickerControllerDelegate & UINavigationControllerDelegate
 
-extension EditShioriPlanDetailViewController: UIImagePickerControllerDelegate & UINavigationControllerDelegate {
-    func imagePickerController(_ picker: UIImagePickerController,
-                               didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-        if let image = info[.originalImage] as? UIImage,
-           let imageData = image.jpegData(compressionQuality: 0.8) {
-            selectedImage = imageData.base64EncodedString()
-            planImageView.image = image
+extension EditShioriPlanDetailViewController: UIImagePickerControllerDelegate,
+                                              UINavigationControllerDelegate {
+    func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+            if let image = info[.originalImage] as? UIImage,
+               let imageData = image.jpegData(compressionQuality: 0.8) {
+                selectedImage = imageData.base64EncodedString()
+                planImageView.image = image
+            }
+            picker.dismiss(animated: true, completion: nil)
         }
-        picker.dismiss(animated: true, completion: nil)
-    }
     
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         picker.dismiss(animated: true)

--- a/TabishioriApp/View/EditShioriPlanViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanViewController.swift
@@ -20,13 +20,6 @@ protocol EditShioriPlanViewControllerDelegate: AnyObject {
 /// しおり予定編集画面
 final class EditShioriPlanViewController: UIViewController {
     
-    // MARK: - Properties
-    
-    /// しおりのデータ
-    private var dataModel: ShioriDataModel?
-    /// 予定のデータ
-    private var planDataModel: PlanDataModel?
-    
     // MARK: - Stored Properties
     
     /// しおり名
@@ -41,6 +34,10 @@ final class EditShioriPlanViewController: UIViewController {
     private let totalCost: String
     /// 背景色
     private var backgroundHex: String = ""
+    /// しおりのデータ
+    private var dataModel: ShioriDataModel?
+    /// 予定のデータ
+    private var planDataModel: PlanDataModel?
     /// 日毎の予定
     private var dailyPlans: [PlanDataModel] = []
     /// RealmManagerのシングルトンインスタンスを取得
@@ -182,6 +179,8 @@ final class EditShioriPlanViewController: UIViewController {
     
     private func configureTableView() {
         planTableView.dataSource = self
+        planTableView.delegate = self
+        
         // カスタムセルを登録
         let nib = UINib(nibName: "ShioriPlanTableViewCell", bundle: nil)
         planTableView.register(nib, forCellReuseIdentifier: "ShioriPlanTableViewCellID")
@@ -278,7 +277,6 @@ extension EditShioriPlanViewController: EditShioriViewControllerDelegate {
     }
 }
 
-
 extension EditShioriPlanViewController: EditShioriPlanDetailViewControllerDelegate {
     func didSavePlan(_ plan: PlanDataModel) {
         fetchDailyPlans()
@@ -286,5 +284,38 @@ extension EditShioriPlanViewController: EditShioriPlanDetailViewControllerDelega
         
         delegateToParent?.didPlanUpdate(plan)
         
+    }
+}
+
+extension EditShioriPlanViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView,
+                   trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath)
+    -> UISwipeActionsConfiguration? {
+        
+        let deleteAction = UIContextualAction(style: .destructive, title: "削除") { [weak self] _, _, done in
+            guard let self = self else { return }
+            let plan = self.dailyPlans[indexPath.row]
+            
+            // Realm から削除
+            self.realmManager.delete(plan, onSuccess: { [weak self] in
+                guard let self = self else { return }
+                // ローカル配列からも除去してテーブル更新
+                self.dailyPlans.remove(at: indexPath.row)
+                tableView.deleteRows(at: [indexPath], with: .automatic)
+                
+                if let visible = tableView.indexPathsForVisibleRows {
+                    tableView.reloadRows(at: visible, with: .none)
+                }
+                done(true)
+                
+            }, onFailure: { error in
+                print("Delete failed: \(error)")
+                done(false)
+            })
+        }
+        
+        let config = UISwipeActionsConfiguration(actions: [deleteAction])
+        config.performsFirstActionWithFullSwipe = true
+        return config
     }
 }

--- a/TabishioriApp/View/EditShioriPlanViewController.xib
+++ b/TabishioriApp/View/EditShioriPlanViewController.xib
@@ -92,7 +92,6 @@
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" red="0.97647058823529409" green="0.82352941176470584" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
                 <constraint firstItem="t7t-Iu-zHa" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="24r-4y-TEj"/>
                 <constraint firstItem="raA-sg-HLY" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="119" id="6q3-QK-WEj"/>

--- a/TabishioriApp/View/PackingListTableViewCell.swift
+++ b/TabishioriApp/View/PackingListTableViewCell.swift
@@ -7,13 +7,31 @@
 
 import UIKit
 
+// MARK: - Protocols
+
+protocol PackingListTableViewCellDelegate: AnyObject {
+    func packingCell(_ cell: PackingListTableViewCell, didCommitText text: String)
+    func packingCellDidToggleCheck(_ cell: PackingListTableViewCell, isChecked: Bool)
+}
+
+// MARK: - Main Type
+
 /// 持ち物リストセル
-final class PackingListTableViewCell: UITableViewCell {
+final class PackingListTableViewCell: UITableViewCell, UITextFieldDelegate {
+    
+    // MARK: - Stored Properties
+    
+    /// デリゲートのプロパティ
+    weak var delegate: PackingListTableViewCellDelegate?
+    /// チェックボックスの初期値
+    private var isChecked = false //Stpred?
     
     // MARK: - IBOutlets
     
-    /// 持ち物ラベル
-    @IBOutlet private weak var packingItemLabel: UILabel!
+    /// 持ち物テキストフィールド
+    @IBOutlet private weak var packingItemTextField: UITextField!
+    /// チェックボックスボタン
+    @IBOutlet private weak var checkBoxButton: UIButton!
     
     // MARK: - View Life-Cycle Methods
     
@@ -22,17 +40,32 @@ final class PackingListTableViewCell: UITableViewCell {
         setupUI()
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        contentView.layer.cornerRadius = 0
+        contentView.layer.maskedCorners = []
+        contentView.layer.masksToBounds = true
+        checkBoxButton.isSelected = false
+    }
+    
     // MARK: - IBActions
-
+    
     /// チェックボックスをタップ
     @IBAction private func checkBoxButtonTapped(_ sender: UIButton) {
+        sender.isSelected.toggle()
+        isChecked = sender.isSelected
+        delegate?.packingCellDidToggleCheck(self, isChecked: isChecked)
     }
     
     // MARK: - Other Methods
-
+    
     private func setupUI() {
         // タイトルのフォントを変更
-        packingItemLabel.font = .setFontZenMaruGothic(size: 15)
+        packingItemTextField.font = .setFontZenMaruGothic(size: 15)
+        packingItemTextField.borderStyle = .none
+        packingItemTextField.backgroundColor = .clear
+        packingItemTextField.delegate = self
+        packingItemTextField.returnKeyType = .done
         
         // セルの枠線を設定
         contentView.layer.borderColor = UIColor.black.cgColor
@@ -40,22 +73,60 @@ final class PackingListTableViewCell: UITableViewCell {
         contentView.clipsToBounds = true
         self.backgroundColor = .clear
         contentView.backgroundColor = .white
+        
+        // チェックボタンの画像をセット
+        checkBoxButton.setImage(UIImage(named: "ic_check_box_out"), for: .normal)
+        checkBoxButton.setImage(UIImage(named: "ic_check_box_in"), for: .selected)
     }
     
     func setup(packingItem: String?, isFirst: Bool, isLast: Bool) {
-        packingItemLabel.text = packingItem?.isEmpty == false ? packingItem : nil
+        packingItemTextField.text = packingItem?.isEmpty == false ? packingItem : nil
         
-        // セルの上下の角を丸める
-        var maskedCorners: CACornerMask = []
-        
-        if isFirst {
-            maskedCorners.insert([.layerMinXMinYCorner, .layerMaxXMinYCorner])
-        }
-        if isLast {
-            maskedCorners.insert([.layerMinXMaxYCorner, .layerMaxXMaxYCorner])
-        }
-        contentView.layer.cornerRadius = 8
-        contentView.layer.maskedCorners = maskedCorners
+        // デフォルトのセルのUI設定
+        contentView.layer.cornerRadius = 0
+        contentView.layer.maskedCorners = []
         contentView.layer.masksToBounds = true
+        
+        
+        // 1セルしかない場合
+        if isFirst && isLast {
+            contentView.layer.cornerRadius = 8
+            contentView.layer.maskedCorners = [
+                .layerMinXMinYCorner, .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner, .layerMaxXMaxYCorner
+            ]
+            return
+        }
+        // 一番最初のセルの上角を丸める
+        if isFirst {
+            contentView.layer.cornerRadius = 8
+            contentView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+            return
+        }
+        // 一番最後のセルの下角を丸める
+        if isLast {
+            contentView.layer.cornerRadius = 8
+            contentView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+            return
+        }
+    }
+    
+    func beginEditing() {
+        packingItemTextField.isUserInteractionEnabled = true
+        packingItemTextField.becomeFirstResponder()
+    }
+    
+    private func endEditingAndCommit() {
+        let newText = (packingItemTextField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        delegate?.packingCell(self, didCommitText: newText)
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        endEditingAndCommit()
+    }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/TabishioriApp/View/PackingListTableViewCell.xib
+++ b/TabishioriApp/View/PackingListTableViewCell.xib
@@ -27,26 +27,26 @@
                             <action selector="checkBoxButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="MGH-Lz-Pqv"/>
                         </connections>
                     </button>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i4Q-Qg-7va">
+                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BEF-mb-9at">
                         <rect key="frame" x="37" y="10" width="271" height="18"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits"/>
+                    </textField>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="i4Q-Qg-7va" secondAttribute="trailing" constant="12" id="8WH-io-qcJ"/>
-                    <constraint firstAttribute="bottom" secondItem="i4Q-Qg-7va" secondAttribute="bottom" constant="10" id="Da2-MP-xFJ"/>
-                    <constraint firstItem="i4Q-Qg-7va" firstAttribute="leading" secondItem="2lB-c0-hma" secondAttribute="trailing" constant="12" id="Xx9-UV-8BD"/>
+                    <constraint firstItem="BEF-mb-9at" firstAttribute="centerY" secondItem="2lB-c0-hma" secondAttribute="centerY" id="ITe-tu-akx"/>
+                    <constraint firstAttribute="bottom" secondItem="BEF-mb-9at" secondAttribute="bottom" constant="10" id="JCv-FV-GHV"/>
+                    <constraint firstAttribute="trailing" secondItem="BEF-mb-9at" secondAttribute="trailing" constant="12" id="M4g-0f-3JI"/>
                     <constraint firstItem="2lB-c0-hma" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="dpX-He-9KR"/>
                     <constraint firstItem="2lB-c0-hma" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="hZF-Xu-Zg1"/>
-                    <constraint firstItem="i4Q-Qg-7va" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="qxM-vb-gLb"/>
-                    <constraint firstItem="i4Q-Qg-7va" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="z9u-7D-GFo"/>
+                    <constraint firstItem="BEF-mb-9at" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="t9b-tb-8VE"/>
+                    <constraint firstItem="BEF-mb-9at" firstAttribute="leading" secondItem="2lB-c0-hma" secondAttribute="trailing" constant="12" id="uNc-NF-0Ie"/>
                 </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
-                <outlet property="packingItemLabel" destination="i4Q-Qg-7va" id="Z1L-gl-uUr"/>
+                <outlet property="checkBoxButton" destination="2lB-c0-hma" id="TcO-G1-OT6"/>
+                <outlet property="packingItemTextField" destination="BEF-mb-9at" id="6cZ-5z-D0x"/>
             </connections>
             <point key="canvasLocation" x="138.93129770992365" y="19.718309859154932"/>
         </tableViewCell>

--- a/TabishioriApp/View/PackingListViewController.xib
+++ b/TabishioriApp/View/PackingListViewController.xib
@@ -47,7 +47,6 @@
                 </tableView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <color key="backgroundColor" red="0.97647058823529409" green="0.82352941176470584" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="cn5-4d-OqH" firstAttribute="top" secondItem="cf8-oi-vMu" secondAttribute="bottom" constant="9" id="1YV-4R-ycA"/>
                 <constraint firstItem="T3n-NP-eQa" firstAttribute="top" secondItem="cn5-4d-OqH" secondAttribute="bottom" constant="10" id="2qx-CH-kXr"/>

--- a/TabishioriApp/View/ShioriViewController.swift
+++ b/TabishioriApp/View/ShioriViewController.swift
@@ -52,7 +52,8 @@ final class ShioriViewController: UIViewController {
     
     /// 持ち物リストボタンをタップ
     @IBAction private func luggageButtonTapped(_ sender: UIButton) {
-        let nextVC = PackingListViewController()
+        let hex = normalizeHex(selectedShiori?.backgroundColor ?? "#FFFFFF")
+        let nextVC = PackingListViewController(backgroundHex: hex)
         let navi = UINavigationController(rootViewController: nextVC)
         navigationController?.present(navi, animated: true)
     }
@@ -180,6 +181,13 @@ final class ShioriViewController: UIViewController {
             }
         }
     }
+    
+    /// 色コードをそろえる
+    private func normalizeHex(_ hex: String) -> String {
+        var trimmedUppercasedHex = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        if !trimmedUppercasedHex.hasPrefix("#") { trimmedUppercasedHex = "#"+trimmedUppercasedHex }
+        return trimmedUppercasedHex
+    }
 }
 
 // MARK: - UIPageViewControllerDataSource
@@ -224,7 +232,8 @@ extension ShioriViewController: CreateShioriPlanViewControllerDelegate {
 extension ShioriViewController: EditShioriPlanViewControllerDelegate {
     /// しおりの情報を更新
     func didShioriUpdate(_ updated: ShioriDataModel) {
-        let currentDisplayedDate = (pageViewController.viewControllers?.first as? ShioriContentViewController)?.pageDate
+        let currentDisplayedDate
+        = (pageViewController.viewControllers?.first as? ShioriContentViewController)?.pageDate
         
         selectedShiori = updated
         configurePages(shiori: updated)


### PR DESCRIPTION
## やったこと
* 持ち物アイテムをRealmに登録する処理を実装
* 各持ち物アイテム、各予定、各しおりの削除処理を実装
* インデントの修正

## 動作確認
- [X] 持ち物アイテムを書き込み、画面遷移しても情報が保持されることを確認した
- [X] 持ち物リスト画面の背景を設定できることを確認した
- [X] 各持ち物アイテム、各予定、各しおりをスライドで削除できることを確認した

## 動画
https://github.com/user-attachments/assets/7daed544-e4c0-49d2-b82f-8dc4e7fe1ce5
https://github.com/user-attachments/assets/4456db31-3f5f-4869-b1d7-9c2a4f0b4bc7


