### PR TITLE
チェックボックスボタンの状態を保持するように修正

### DIFF
--- a/TabishioriApp/Model/PlanDataModel.swift
+++ b/TabishioriApp/Model/PlanDataModel.swift
@@ -15,6 +15,7 @@ final class PlanDataModel: Object {
     @Persisted var endTime: Date?
     @Persisted var planContent: String = ""
     @Persisted var planReservation: Bool = false
+    @Persisted var reservationIsChecked: Bool = false
     @Persisted var planCost: Int = 0
     @Persisted var planURL: String = ""
     @Persisted var planImage: String?

--- a/TabishioriApp/View/CreateShioriPlanViewController.swift
+++ b/TabishioriApp/View/CreateShioriPlanViewController.swift
@@ -89,6 +89,8 @@ final class CreateShioriPlanViewController: UIViewController {
     @IBOutlet private weak var endTimeTextField: UITextField!
     /// 予定内容記入欄
     @IBOutlet private weak var planTextView: UITextView!
+    /// 予約可否ボタン
+    @IBOutlet weak var reservationCheckButton: UIButton!
     /// 費用記入欄
     @IBOutlet private weak var costTextField: UITextField!
     /// URL記入欄
@@ -106,9 +108,10 @@ final class CreateShioriPlanViewController: UIViewController {
             dateTextField.text = dateFormat(date, pattern: "yyyy年M月d日")
             datePickerDate.date = date
         }
-        setupFont()
+        setupUI()
         configureTextField()
         configureTextView()
+        setReservationCheckBox()
         configureNavigationBar()
         configureDatePicker()
     }
@@ -119,12 +122,6 @@ final class CreateShioriPlanViewController: UIViewController {
     @IBAction private func checkBoxButtonTapped(_ sender: UIButton) {
         sender.isSelected.toggle()
         selectedReservation = sender.isSelected
-        
-        if sender.isSelected {
-            sender.setImage(UIImage(named: "ic_check_box_in"), for: .normal)
-        } else {
-            sender.setImage(UIImage(named: "ic_check_box_out"), for: .normal)
-        }
     }
     
     /// 画像をを挿入するボタンをタップ
@@ -149,7 +146,7 @@ final class CreateShioriPlanViewController: UIViewController {
     
     // MARK: - Other Methods
     
-    private func setupFont() {
+    private func setupUI() {
         // タイトルのフォントを変更
         titleLabel.font = .setFontZenMaruGothic(size: 24)
         titleLabel.layer.shadowColor = UIColor(white: 0.0, alpha: 0.3).cgColor
@@ -265,7 +262,7 @@ final class CreateShioriPlanViewController: UIViewController {
         endTimeTextField.inputView = datePickerEndTime
         endTimeTextField.inputAccessoryView = pickerToolbar
     }
-
+    
     @objc private func dateChanged() {
         dateTextField.text = dateFormat(datePickerDate.date, pattern: "yyyy年M月d日")
         // 日付を登録
@@ -289,6 +286,17 @@ final class CreateShioriPlanViewController: UIViewController {
     private func dateFormat(_ date: Date, pattern: String) -> String {
         dateFormatter.dateFormat = pattern
         return dateFormatter.string(from: date)
+    }
+    
+    /// 予約チェックボックスの画像表示
+    private func setReservationCheckBox() {
+        reservationCheckButton.setImage(UIImage(named: "ic_check_box_out"), for: .normal)   // false用
+        reservationCheckButton.setImage(UIImage(named: "ic_check_box_in"),  for: .selected) // true用
+        reservationCheckButton.configurationUpdateHandler = { button in
+            var configuration = button.configuration
+            configuration?.background.backgroundColor = .clear
+            button.configuration = configuration
+        }
     }
     
     /// ツールバーの設定

--- a/TabishioriApp/View/CreateShioriPlanViewController.xib
+++ b/TabishioriApp/View/CreateShioriPlanViewController.xib
@@ -21,6 +21,7 @@
                 <outlet property="planImageView" destination="YTH-DL-nVM" id="kvr-50-lgN"/>
                 <outlet property="planLabel" destination="eRf-Ls-eSV" id="WeL-uZ-Gfo"/>
                 <outlet property="planTextView" destination="oT8-xJ-Pn5" id="L7J-mR-fdK"/>
+                <outlet property="reservationCheckButton" destination="LjZ-G0-vdF" id="7Jd-1y-Im2"/>
                 <outlet property="reservationLabel" destination="Ce9-Ae-iUE" id="pgM-pQ-EqN"/>
                 <outlet property="startTimeLabel" destination="QlO-Ti-xos" id="osf-LK-m1g"/>
                 <outlet property="startTimeTextField" destination="STe-e6-snH" id="bXF-yN-obE"/>
@@ -237,7 +238,7 @@
         </view>
     </objects>
     <resources>
-        <image name="ic_check_box_out" width="15" height="15"/>
+        <image name="ic_check_box_out" width="30" height="30"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.swift
@@ -399,6 +399,11 @@ final class EditShioriPlanDetailViewController: UIViewController {
     private func setReservationCheckBox() {
         reservationCheckButton.setImage(UIImage(named: "ic_check_box_out"), for: .normal)   // false用
         reservationCheckButton.setImage(UIImage(named: "ic_check_box_in"),  for: .selected) // true用
+        reservationCheckButton.configurationUpdateHandler = { button in
+            var configuration = button.configuration
+            configuration?.background.backgroundColor = .clear
+            button.configuration = configuration
+        }
     }
     
     /// 画像の型の変更

--- a/TabishioriApp/View/EditShioriPlanViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanViewController.swift
@@ -213,7 +213,8 @@ final class EditShioriPlanViewController: UIViewController {
                      isReserved: plan.planReservation,
                      cost: plan.planCost,
                      hasURL: hasURL,
-                     planImage: imageName)
+                     planImage: imageName,
+                     isChecked: plan.reservationIsChecked)
     }
     
     /// しおりの情報を更新する
@@ -269,6 +270,10 @@ extension EditShioriPlanViewController: ShioriPlanTableViewCellDelegate {
         nextVC.delegate = self
         navigationController?.pushViewController(nextVC, animated: true)
     }
+    
+    func planCell(_ cell: ShioriPlanTableViewCell, didToggleCheck isChecked: Bool) {
+        // 編集画面ではチェックボックスボタンを表示しない
+    }
 }
 
 extension EditShioriPlanViewController: EditShioriViewControllerDelegate {
@@ -300,20 +305,20 @@ extension EditShioriPlanViewController: UITableViewDelegate {
             self.realmManager.delete(
                 plan,
                 onSuccess: { [weak self] in
-                guard let self = self else { return }
-                // ローカル配列からも除去してテーブル更新
-                self.dailyPlans.remove(at: indexPath.row)
-                tableView.deleteRows(at: [indexPath], with: .automatic)
-                
-                if let visible = tableView.indexPathsForVisibleRows {
-                    tableView.reloadRows(at: visible, with: .none)
-                }
-                done(true)
-                
-            }, onFailure: { error in
-                print("Delete failed: \(error)")
-                done(false)
-            })
+                    guard let self = self else { return }
+                    // ローカル配列からも除去してテーブル更新
+                    self.dailyPlans.remove(at: indexPath.row)
+                    tableView.deleteRows(at: [indexPath], with: .automatic)
+                    
+                    if let visible = tableView.indexPathsForVisibleRows {
+                        tableView.reloadRows(at: visible, with: .none)
+                    }
+                    done(true)
+                    
+                }, onFailure: { error in
+                    print("Delete failed: \(error)")
+                    done(false)
+                })
         }
         
         let config = UISwipeActionsConfiguration(actions: [deleteAction])

--- a/TabishioriApp/View/PackingListTableViewCell.swift
+++ b/TabishioriApp/View/PackingListTableViewCell.swift
@@ -24,7 +24,7 @@ final class PackingListTableViewCell: UITableViewCell {
     /// デリゲートのプロパティ
     weak var delegate: PackingListTableViewCellDelegate?
     /// チェックボックスの初期値
-    private var isChecked = false //Stpred?
+    private var isChecked = false
     
     // MARK: - IBOutlets
     
@@ -77,7 +77,7 @@ final class PackingListTableViewCell: UITableViewCell {
         // チェックボタンの画像をセット
         checkBoxButton.setImage(UIImage(named: "ic_check_box_out"), for: .normal)
         checkBoxButton.setImage(UIImage(named: "ic_check_box_in"), for: .selected)
-
+        
         // チェックボタンのUI設定
         checkBoxButton.configurationUpdateHandler = { button in
             var configuration = button.configuration
@@ -116,6 +116,11 @@ final class PackingListTableViewCell: UITableViewCell {
             contentView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
             return
         }
+    }
+    
+    func configureCheckedState(_ isChecked: Bool) {
+        self.isChecked = isChecked
+        checkBoxButton.isSelected = isChecked
     }
     
     func beginEditing() {

--- a/TabishioriApp/View/PackingListViewController.swift
+++ b/TabishioriApp/View/PackingListViewController.swift
@@ -169,6 +169,7 @@ extension PackingListViewController: UITableViewDataSource {
         let isFirstCell = indexPath.row == 0
         let isLastCell = indexPath.row == items.count - 1
         cell.setup(packingItem: item.name, isFirst: isFirstCell, isLast: isLastCell)
+        cell.configureCheckedState(item.isChecked)
         cell.delegate = self
         return cell
     }
@@ -187,7 +188,6 @@ extension PackingListViewController: UITableViewDelegate {
         
         let addButton = UIButton(type: .system)
         addButton.setImage(UIImage(named: "ic_addlist"), for: .normal)
-        //addButton.tintColor = .black
         addButton.translatesAutoresizingMaskIntoConstraints = false
         addButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
         

--- a/TabishioriApp/View/ShioriPlanTableViewCell.swift
+++ b/TabishioriApp/View/ShioriPlanTableViewCell.swift
@@ -11,6 +11,7 @@ import UIKit
 
 protocol ShioriPlanTableViewCellDelegate: AnyObject {
     func didTapRightButton(in cell: ShioriPlanTableViewCell)
+    func planCell(_ cell: ShioriPlanTableViewCell, didToggleCheck isChecked: Bool)
 }
 
 // MARK: - Main Type
@@ -36,6 +37,7 @@ final class ShioriPlanTableViewCell: UITableViewCell {
         let cost: Int?
         let hasURL: Bool
         let planImage: String?
+        var isChecked: Bool
     }
     /// 編集モード初期値
     private var isEditMode: Bool = false
@@ -72,12 +74,7 @@ final class ShioriPlanTableViewCell: UITableViewCell {
     /// チェックボックスをタップ
     @IBAction private func checkBoxButtonTapped(_ sender: UIButton) {
         sender.isSelected.toggle()
-        
-        if sender.isSelected {
-            sender.setImage(UIImage(named: "ic_check_box_in"), for: .normal)
-        } else {
-            sender.setImage(UIImage(named: "ic_check_box_out"), for: .normal)
-        }
+        delegate?.planCell(self, didToggleCheck: sender.isSelected)
     }
     
     /// URLボタンをタップ
@@ -128,6 +125,8 @@ final class ShioriPlanTableViewCell: UITableViewCell {
         checkBoxButton.isHidden = !item.isReserved
         
         // チェックボタンのUI設定
+        checkBoxButton.setImage(UIImage(named: "ic_check_box_out"), for: .normal)
+        checkBoxButton.setImage(UIImage(named: "ic_check_box_in"),  for: .selected)
         checkBoxButton.configurationUpdateHandler = { button in
             var configuration = button.configuration
             configuration?.background.backgroundColor = .clear
@@ -145,6 +144,9 @@ final class ShioriPlanTableViewCell: UITableViewCell {
         if isEditMode{
             // 修正ボタンを表示
             rightButton.setImage(UIImage(named: "ic_edit"), for: .normal)
+            // チェックボックスボタンを表示
+            checkBoxButton.isSelected = item.isChecked
+            checkBoxButton.isUserInteractionEnabled = false
         } else {
             // URLボタンを表示
             rightButton.setImage(UIImage(named: "ic_url"), for: .normal)
@@ -154,6 +156,10 @@ final class ShioriPlanTableViewCell: UITableViewCell {
             } else {
                 rightButton.isHidden = true
             }
+            // チェックボックスボタンを表示
+            checkBoxButton.isSelected = item.isChecked
+            checkBoxButton.isUserInteractionEnabled = item.isReserved
+            
         }
         
         // 画像がある場合表示


### PR DESCRIPTION
## やったこと
* しおり画面で予約チェックボックボタンにチェックを入れた時、画面遷移して戻ってきても状態が保持されるように修正
* しおり編集画面では、予約チェックボックスボタンをタップできないように修正
* 持ち物リスト画面で、チェックボックスにチェックを入れた時、画面遷移して戻ってきても状態が保持されるように修正
* 新しいしおり作成画面で、要予約のチェックボックスをタップするとボタンが青くなってしまう処理を修正
* しおり情報修正画面で、要予約のチェックボックスボタンをタップするとボタンが青くなってしまう処理を修正

## 動作確認
- [X] チェックボックスの状態が画面遷移後も保持できることを確認した
- [X] チェックボックスボタンをタップした際も、画像が青くならないことを確認した

## 動画
https://github.com/user-attachments/assets/d4cd25bc-1a94-4212-8414-cd5fb2d76fbc