### PR TITLE
しおりのタイトルに文字数制限を追加

### DIFF
--- a/TabishioriApp/View/CreateShioriViewController.swift
+++ b/TabishioriApp/View/CreateShioriViewController.swift
@@ -296,6 +296,12 @@ final class CreateShioriViewController: UIViewController {
             selectedBackgroundColor = "#FFFFFF"
         }
         
+        // タイトルは18文字以下にする
+        if selectedShioriName.count > 18 {
+            showAlert(title: "タイトルは18文字以下にしてください")
+            return
+        }
+        
         let dataModel = ShioriDataModel()
         dataModel.shioriName = selectedShioriName
         dataModel.startDate = startDate

--- a/TabishioriApp/View/EditShioriPlanViewController.xib
+++ b/TabishioriApp/View/EditShioriPlanViewController.xib
@@ -25,7 +25,7 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="マレーシア旅行" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7t-Iu-zHa">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="マレーシア旅行" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t7t-Iu-zHa">
                     <rect key="frame" x="91.666666666666671" y="117.99999999999999" width="209.66666666666663" height="38.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="32"/>
                     <nil key="textColor"/>
@@ -93,6 +93,7 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <constraints>
+                <constraint firstItem="kcX-km-3ON" firstAttribute="leading" secondItem="t7t-Iu-zHa" secondAttribute="trailing" constant="5" id="0l2-di-sE7"/>
                 <constraint firstItem="t7t-Iu-zHa" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="24r-4y-TEj"/>
                 <constraint firstItem="6f9-Sb-EbQ" firstAttribute="top" secondItem="6Lu-E2-D4j" secondAttribute="bottom" constant="10" id="8by-gm-GIU"/>
                 <constraint firstItem="xWt-n5-GaN" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="Cx9-KH-Ktf"/>
@@ -103,14 +104,15 @@
                 <constraint firstItem="6Lu-E2-D4j" firstAttribute="top" secondItem="raA-sg-HLY" secondAttribute="bottom" id="W7Z-Pa-5SN"/>
                 <constraint firstItem="raA-sg-HLY" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="30" id="aJW-6O-LTw"/>
                 <constraint firstItem="vDz-Xe-HKT" firstAttribute="top" secondItem="t7t-Iu-zHa" secondAttribute="bottom" id="aad-vH-wOC"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kcX-km-3ON" secondAttribute="trailing" constant="5" id="bR4-LE-gea"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="6f9-Sb-EbQ" secondAttribute="trailing" constant="4" id="cUV-75-uyA"/>
+                <constraint firstItem="t7t-Iu-zHa" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="dxh-8w-NXS"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="vDz-Xe-HKT" secondAttribute="trailing" constant="13" id="fjJ-wX-40c"/>
                 <constraint firstItem="xWt-n5-GaN" firstAttribute="top" secondItem="t7t-Iu-zHa" secondAttribute="bottom" constant="22" id="gVp-0L-01S"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="6f9-Sb-EbQ" secondAttribute="bottom" constant="13" id="h3a-GJ-QjR"/>
-                <constraint firstItem="kcX-km-3ON" firstAttribute="leading" secondItem="t7t-Iu-zHa" secondAttribute="trailing" constant="5" id="kZx-Y6-bPw"/>
                 <constraint firstItem="kcX-km-3ON" firstAttribute="centerY" secondItem="t7t-Iu-zHa" secondAttribute="centerY" id="zuI-jz-5pY"/>
             </constraints>
-            <point key="canvasLocation" x="41" y="-11"/>
+            <point key="canvasLocation" x="40.458015267175568" y="-11.267605633802818"/>
         </view>
     </objects>
     <resources>

--- a/TabishioriApp/View/EditShioriViewController.swift
+++ b/TabishioriApp/View/EditShioriViewController.swift
@@ -367,6 +367,12 @@ final class EditShioriViewController: UIViewController {
     
     /// しおりデータを更新する
     private func update(startDate: Date, endDate: Date) {
+        // タイトルは18文字以下にする
+        if selectedShioriName.count > 18 {
+            showAlert(title: "タイトルは18文字以下にしてください")
+            return
+        }
+        
         guard let model = dataModel else { return }
         
         realmManager.update(

--- a/TabishioriApp/View/ShioriContentViewController.xib
+++ b/TabishioriApp/View/ShioriContentViewController.xib
@@ -25,8 +25,8 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="マレーシア旅行" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wgg-b3-jzh">
-                    <rect key="frame" x="91.666666666666671" y="117.99999999999999" width="209.66666666666663" height="38.333333333333329"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="マレーシア旅行" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wgg-b3-jzh">
+                    <rect key="frame" x="16" y="117.99999999999999" width="361" height="38.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="32"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -86,7 +86,9 @@
                 <constraint firstItem="ngj-ba-HYX" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="30" id="5Of-rS-txW"/>
                 <constraint firstItem="mmA-uO-VZU" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="AdI-2U-7JJ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="WDu-5x-Z0c" secondAttribute="trailing" constant="4" id="CiY-sL-KXL"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Wgg-b3-jzh" secondAttribute="trailing" constant="16" id="HYf-rT-XcI"/>
                 <constraint firstItem="tHz-tq-MMb" firstAttribute="top" secondItem="ngj-ba-HYX" secondAttribute="bottom" id="MY8-cK-laa"/>
+                <constraint firstItem="Wgg-b3-jzh" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="QYv-34-txQ"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="tHz-tq-MMb" secondAttribute="trailing" constant="4" id="V3r-YF-XO1"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="ZXC-5B-A4C" secondAttribute="trailing" constant="13" id="XgG-tD-jRu"/>
                 <constraint firstItem="mmA-uO-VZU" firstAttribute="top" secondItem="ZXC-5B-A4C" secondAttribute="bottom" id="byr-SR-v9g"/>


### PR DESCRIPTION
## やったこと
* しおりのタイトルの文字数制限を実装
* しおり画面のタイトルが長い時は2行になるように修正

## 動作確認
- [X] しおりのタイトルが19文字以上は記入できないことを確認した
- [X] 長いしおりタイトルでも、しおりタイトルが２行になる画面内が表示できることを確認した



## 画像
Before
| しおり画面 | しおり編集画面 |
| --- | --- |
|<img width="240" src="https://github.com/user-attachments/assets/4ab3ca31-34dc-4eed-8c1a-34b5a6013593" />|<img width="240" src="https://github.com/user-attachments/assets/87aa1bf6-8200-4025-9911-6bf1f500b9a5" />

After
| しおり画面 | しおり編集画面 |
| --- | --- |
|<img width="240" src="https://github.com/user-attachments/assets/c1ce315a-0201-4ba2-8993-239fa17e4e8d" />|<img width="240" src="https://github.com/user-attachments/assets/41624a17-8878-4243-a258-695289aa5ec7" />


## 動画
https://github.com/user-attachments/assets/5bcdcc38-b447-4304-9d8e-db7a3df281f1


