### PR TITLE
しおり作成画面としおり情報編集画面の不具合修正

### DIFF
--- a/TabishioriApp/View/CreateShioriPlanViewController.swift
+++ b/TabishioriApp/View/CreateShioriPlanViewController.swift
@@ -377,6 +377,13 @@ final class CreateShioriPlanViewController: UIViewController {
         }
         
         if validateTitles.isEmpty {
+            guard validateCostForm() else {
+                return
+            }
+            guard validateURLForm() else {
+                return
+            }
+            
             // 日付と内容が記載されている場合、登録処理を行う
             let planDate = selectedDate!
             let startTime = selectedStartTime!
@@ -385,6 +392,66 @@ final class CreateShioriPlanViewController: UIViewController {
             // 未入力項目がある場合、アラートを表示
             showAlert(title: String(format: validateMessage, validateTitles.joined(separator: "、")))
         }
+    }
+    
+    // 費用バリデーション
+    private func validateCostForm() -> Bool {
+        let raw = (costTextField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // 費用が空欄ならそのまま返す
+        guard raw.isEmpty == false else {
+            selectedCost = nil
+            return true
+        }
+        
+        // 全角→半角にし、カンマを削除
+        let half = raw.applyingTransform(.fullwidthToHalfwidth, reverse: false) ?? raw
+        let digitsOnly = half.replacingOccurrences(of: ",", with: "")
+        
+        // 数字以外ならアラートを表示する
+        let isAllDigits = CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: digitsOnly))
+        guard isAllDigits, let value = Int(digitsOnly) else {
+            showAlert(title: "費用は数字のみで入力してください")
+            return false
+        }
+        
+        selectedCost = value
+        return true
+    }
+    
+    /// URLバリデーション
+    private func validateURLForm() -> Bool {
+        let raw = (urlTextField.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        /// URLが空欄ならそのまま返す
+        guard raw.isEmpty == false else {
+            selectedURL = ""
+            return true
+        }
+        
+        // 全角→半角に正規化
+        let normalizedURL = raw.applyingTransform(.fullwidthToHalfwidth, reverse: false) ?? raw
+        
+        // http(s)かを確認
+        guard normalizedURL.lowercased().hasPrefix("http://") || normalizedURL.lowercased().hasPrefix("https://") else {
+                showAlert(title: "URLは http(s):// から記入してください")
+                return false
+            }
+        
+        // FQDN確認
+        let URLpattern = #"^(?:https?):\/\/(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?::\d+)?(?:\/[^\s#?]*)?(?:\?[^\s#]*)?(?:#[^\s]*)?$"#
+        let regex = try! NSRegularExpression(pattern: URLpattern, options: .caseInsensitive)
+        let range = NSRange(normalizedURL.startIndex..., in: normalizedURL)
+        let match = regex.firstMatch(in: normalizedURL, range: range)
+        let isWholeMatch = (match?.range.location == 0 && match?.range.length == range.length)
+
+        guard isWholeMatch else {
+            showAlert(title: "URLの形式が正しくありません")
+            return false
+        }
+        
+        selectedURL = normalizedURL
+        return true
     }
     
     /// データを保存する

--- a/TabishioriApp/View/CreateShioriPlanViewController.swift
+++ b/TabishioriApp/View/CreateShioriPlanViewController.swift
@@ -432,9 +432,9 @@ final class CreateShioriPlanViewController: UIViewController {
         // 全角→半角に正規化
         let normalizedURL = raw.applyingTransform(.fullwidthToHalfwidth, reverse: false) ?? raw
         
-        // http(s)かを確認
-        guard normalizedURL.lowercased().hasPrefix("http://") || normalizedURL.lowercased().hasPrefix("https://") else {
-                showAlert(title: "URLは http(s):// から記入してください")
+        // httpsかを確認
+        guard normalizedURL.lowercased().hasPrefix("https://") else {
+                showAlert(title: "URLは https:// から記入してください")
                 return false
             }
         

--- a/TabishioriApp/View/CreateShioriPlanViewController.xib
+++ b/TabishioriApp/View/CreateShioriPlanViewController.xib
@@ -190,6 +190,12 @@
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="円" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MVb-Id-2Db">
+                    <rect key="frame" x="350" y="442.33333333333331" width="16" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -199,12 +205,14 @@
                 <constraint firstItem="1BQ-e8-wgK" firstAttribute="leading" secondItem="6Yp-Ha-m9l" secondAttribute="trailing" constant="11" id="3ne-gy-vg8"/>
                 <constraint firstItem="h6g-h1-0Ny" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="4CY-G9-O00"/>
                 <constraint firstItem="IS1-36-ON3" firstAttribute="top" secondItem="QlO-Ti-xos" secondAttribute="bottom" constant="13" id="716-OF-8lu"/>
+                <constraint firstItem="MVb-Id-2Db" firstAttribute="bottom" secondItem="O08-qB-Fg6" secondAttribute="bottom" id="8ry-uO-LhF"/>
                 <constraint firstItem="uyu-jS-KXW" firstAttribute="centerY" secondItem="IS1-36-ON3" secondAttribute="centerY" id="AYE-fb-duc"/>
                 <constraint firstItem="Rbx-uK-GOb" firstAttribute="top" secondItem="6HB-Vu-boU" secondAttribute="bottom" constant="30" id="CGi-0M-Fxg"/>
                 <constraint firstItem="6HB-Vu-boU" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="D5J-3E-IH0"/>
                 <constraint firstItem="1BQ-e8-wgK" firstAttribute="centerY" secondItem="6Yp-Ha-m9l" secondAttribute="centerY" id="Dog-yL-7It"/>
                 <constraint firstItem="6Yp-Ha-m9l" firstAttribute="top" secondItem="cQY-mj-OqS" secondAttribute="bottom" constant="17" id="GIo-bj-rQ9"/>
                 <constraint firstItem="YTH-DL-nVM" firstAttribute="leading" secondItem="6Yp-Ha-m9l" secondAttribute="leading" id="J0o-lk-Vaf"/>
+                <constraint firstItem="MVb-Id-2Db" firstAttribute="leading" secondItem="O08-qB-Fg6" secondAttribute="trailing" constant="6" id="JWf-8w-t5q"/>
                 <constraint firstItem="Rbx-uK-GOb" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="38" id="LeZ-5Z-Ufp"/>
                 <constraint firstItem="mWB-bk-1ER" firstAttribute="top" secondItem="1BQ-e8-wgK" secondAttribute="bottom" constant="15" id="NpK-wR-LnT"/>
                 <constraint firstItem="eRf-Ls-eSV" firstAttribute="leading" secondItem="IS1-36-ON3" secondAttribute="leading" id="W2g-4I-NIR"/>
@@ -231,9 +239,6 @@
                 <constraint firstItem="cQY-mj-OqS" firstAttribute="leading" secondItem="Rbx-uK-GOb" secondAttribute="leading" id="xXt-eM-IN3"/>
                 <constraint firstItem="O08-qB-Fg6" firstAttribute="leading" secondItem="cQY-mj-OqS" secondAttribute="trailing" constant="11" id="y6G-lf-KkT"/>
             </constraints>
-            <userDefinedRuntimeAttributes>
-                <userDefinedRuntimeAttribute type="boolean" keyPath="keyPath" value="YES"/>
-            </userDefinedRuntimeAttributes>
             <point key="canvasLocation" x="64.885496183206101" y="-11.267605633802818"/>
         </view>
     </objects>

--- a/TabishioriApp/View/EditShioriPlanDetailViewController.xib
+++ b/TabishioriApp/View/EditShioriPlanDetailViewController.xib
@@ -173,7 +173,7 @@
                         <constraint firstAttribute="width" constant="263" id="cGM-qd-TtY"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                    <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                    <textInputTraits key="textInputTraits" keyboardType="numbersAndPunctuation" returnKeyType="done"/>
                 </textField>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Oe-1q-fId">
                     <rect key="frame" x="350" y="516.33333333333337" width="24" height="14"/>
@@ -190,6 +190,12 @@
                         <constraint firstAttribute="height" constant="188" id="v9J-Yc-lA4"/>
                     </constraints>
                 </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="円" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VIl-L4-jeK">
+                    <rect key="frame" x="350" y="442.33333333333331" width="16" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -220,6 +226,8 @@
                 <constraint firstItem="I9P-Og-aRb" firstAttribute="leading" secondItem="eqq-UL-jPC" secondAttribute="trailing" constant="55" id="R5J-5v-6iR"/>
                 <constraint firstItem="5UA-I9-kEK" firstAttribute="leading" secondItem="wma-O4-buD" secondAttribute="trailing" constant="22" id="T6M-NF-XQD"/>
                 <constraint firstItem="7la-AK-HrU" firstAttribute="leading" secondItem="eqq-UL-jPC" secondAttribute="leading" id="The-M4-6Vn"/>
+                <constraint firstItem="VIl-L4-jeK" firstAttribute="leading" secondItem="gY6-ck-hzU" secondAttribute="trailing" constant="6" id="UY4-cJ-S6l"/>
+                <constraint firstItem="VIl-L4-jeK" firstAttribute="bottom" secondItem="gY6-ck-hzU" secondAttribute="bottom" id="VYk-cS-sHU"/>
                 <constraint firstItem="wma-O4-buD" firstAttribute="leading" secondItem="eqq-UL-jPC" secondAttribute="leading" id="WpN-id-2xC"/>
                 <constraint firstItem="gRE-3L-KkF" firstAttribute="top" secondItem="wma-O4-buD" secondAttribute="bottom" constant="17" id="YLU-pL-Mqn"/>
                 <constraint firstItem="dhr-UY-4kP" firstAttribute="top" secondItem="WuO-sh-nNa" secondAttribute="bottom" constant="5" id="ZQR-7z-E83"/>
@@ -236,7 +244,7 @@
         </view>
     </objects>
     <resources>
-        <image name="ic_check_box_out" width="15" height="15"/>
+        <image name="ic_check_box_out" width="30" height="30"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/TabishioriApp/View/EditShioriPlanViewController.swift
+++ b/TabishioriApp/View/EditShioriPlanViewController.swift
@@ -13,6 +13,7 @@ import RealmSwift
 protocol EditShioriPlanViewControllerDelegate: AnyObject {
     func didShioriUpdate(_ updated: ShioriDataModel)
     func didPlanUpdate(_ plan: PlanDataModel)
+    func didPlanDelete(_ vc: EditShioriPlanViewController,for date: Date?)
 }
 
 // MARK: - Main Type
@@ -301,6 +302,8 @@ extension EditShioriPlanViewController: UITableViewDelegate {
             guard let self = self else { return }
             let plan = self.dailyPlans[indexPath.row]
             
+            let affectedDate = plan.planDate
+            
             // Realm から削除
             self.realmManager.delete(
                 plan,
@@ -313,6 +316,7 @@ extension EditShioriPlanViewController: UITableViewDelegate {
                     if let visible = tableView.indexPathsForVisibleRows {
                         tableView.reloadRows(at: visible, with: .none)
                     }
+                    self.delegateToParent?.didPlanDelete(self, for: affectedDate)
                     done(true)
                     
                 }, onFailure: { error in

--- a/TabishioriApp/View/ShioriViewController.swift
+++ b/TabishioriApp/View/ShioriViewController.swift
@@ -317,6 +317,17 @@ extension ShioriViewController: EditShioriPlanViewControllerDelegate {
             }
         }
     }
+
+    /// 予定の削除後更新
+    func didPlanDelete(_ vc: EditShioriPlanViewController, for date: Date?) {
+        guard let date else { return updateAllPagesWithPlans() }
+        let cal = Calendar.current
+            (pages.first {
+                guard let p = $0 as? ShioriContentViewController else { return false }
+                return cal.isDate(p.pageDate, inSameDayAs: date)
+            } as? ShioriContentViewController)?
+                .fetchAndDistributePlans()
+}
 }
 
 


### PR DESCRIPTION
## やったこと
* 費用とURLのバリデーションを追加
* 削除したらしおり画面を更新する処理を追加

## 動作確認
- [X] 費用に数字以外が入ると予定を保存できないことを確認した
- [X] URLにIPアドレスだったり、http(s)以外の通信で記載すると保存できないことを確認した
- [X] 予定を削除したらしおりの予定一覧が更新されることを確認した

## 動画
<video width="240" src="https://github.com/user-attachments/assets/930742fd-e8e9-4b0a-bff1-220d239dbe4c">|

